### PR TITLE
Add --since date filter to sync and manual-categorize

### DIFF
--- a/finances/cli.py
+++ b/finances/cli.py
@@ -80,6 +80,18 @@ TELLER_CONNECT_HTML = """
 """
 
 
+def parse_since_date(since: str | None):
+    """Parse a YYYY-MM-DD date string, printing an error and returning None on failure."""
+    import datetime
+    if not since:
+        return None
+    try:
+        return datetime.date.fromisoformat(since)
+    except ValueError:
+        console.print(f"[red]Invalid date format: {since}. Use YYYY-MM-DD.[/red]")
+        return None
+
+
 @click.group()
 def cli():
     """Personal finance tracker - aggregate and analyze spending."""
@@ -502,10 +514,15 @@ def link():
 @cli.command()
 @click.option("--account-id", "-a", type=int, help="Sync specific account by ID")
 @click.option("--count", "-n", default=100, help="Number of transactions to fetch per account (default 100)")
-def sync(account_id: int | None, count: int):
+@click.option("--since", default=None, help="Only import transactions on or after this date (YYYY-MM-DD).")
+def sync(account_id: int | None, count: int, since: str | None):
     """Sync transactions from connected bank accounts."""
     from finances.models import Account, Transaction, TransactionSource
     from finances.teller import TellerClient, parse_teller_date
+
+    since_date = parse_since_date(since)
+    if since and since_date is None:
+        return
 
     db = SessionLocal()
     try:
@@ -533,6 +550,9 @@ def sync(account_id: int | None, count: int):
 
             new_count = 0
             for txn_data in transactions:
+                if since_date and parse_teller_date(txn_data["date"]) < since_date:
+                    continue
+
                 # Skip if transaction already exists
                 existing = db.query(Transaction).filter(
                     Transaction.external_transaction_id == txn_data["id"]
@@ -697,20 +717,26 @@ def rules():
 
 
 @cli.command()
-def manual_categorize():
+@click.option("--since", default=None, help="Only show transactions on or after this date (YYYY-MM-DD).")
+def manual_categorize(since):
     """Interactively categorize uncategorized transactions."""
     from finances.models import Transaction, Category
+
+    since_date = parse_since_date(since)
+    if since and since_date is None:
+        return
 
     db = SessionLocal()
     try:
         while True:
             # Get uncategorized transactions
-            uncategorized = (
+            query = (
                 db.query(Transaction)
                 .filter(Transaction.category_id.is_(None))
-                .order_by(Transaction.date.desc())
-                .all()
             )
+            if since_date:
+                query = query.filter(Transaction.date >= since_date)
+            uncategorized = query.order_by(Transaction.date.desc()).all()
 
             if not uncategorized:
                 console.print("[green]No uncategorized transactions remaining![/green]")

--- a/tests/test_since_filter.py
+++ b/tests/test_since_filter.py
@@ -1,0 +1,53 @@
+"""Unit tests for --since date filtering."""
+
+import datetime
+import pytest
+from click.testing import CliRunner
+
+from finances.cli import parse_since_date, cli
+
+
+class TestParseSinceDate:
+    def test_valid_date(self):
+        assert parse_since_date("2026-04-15") == datetime.date(2026, 4, 15)
+
+    def test_none_returns_none(self):
+        assert parse_since_date(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert parse_since_date("") is None
+
+    def test_invalid_format_returns_none(self):
+        assert parse_since_date("not-a-date") is None
+
+    def test_invalid_month_returns_none(self):
+        assert parse_since_date("2026-13-01") is None
+
+    def test_wrong_separator_returns_none(self):
+        assert parse_since_date("2026/04/15") is None
+
+
+class TestManualCategorizeSinceOption:
+    def test_invalid_since_exits_cleanly(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["manual-categorize", "--since", "bad-date"])
+        assert result.exit_code == 0
+        assert "Invalid date format" in result.output
+
+    def test_help_shows_since_option(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["manual-categorize", "--help"])
+        assert "--since" in result.output
+
+
+class TestSyncSinceOption:
+    def test_invalid_since_exits_cleanly(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["sync", "--since", "bad-date"])
+        assert result.exit_code == 0
+        assert "Invalid date format" in result.output
+
+    def test_help_shows_since_option(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["sync", "--help"])
+        assert "--since" in result.output


### PR DESCRIPTION
## Summary
- Adds `--since YYYY-MM-DD` option to `finances sync` and `finances manual-categorize`
- Extracts shared `parse_since_date()` helper so both commands use the same validation logic
- `sync --since` skips importing transactions older than the given date
- `manual-categorize --since` filters the uncategorized transaction list to the given date range

## Test plan
- [ ] `finances sync --since 2026-04-15` — only imports transactions on or after April 15
- [ ] `finances manual-categorize --since 2026-04-15` — only shows transactions on or after April 15
- [ ] `finances sync --since bad-date` — prints error and exits cleanly
- [ ] `finances manual-categorize --since bad-date` — prints error and exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)